### PR TITLE
Bugfixes, style updates for coding challenge.

### DIFF
--- a/country-card-block.php
+++ b/country-card-block.php
@@ -49,7 +49,7 @@ add_action( 'init', __NAMESPACE__ . '\\disable_emojis' );
  * @return array Difference between the two arrays.
  */
 function remove_emoji_dns_prefetch( $urls, $relation_type ) {
-	if ( 'dns-prefetch' == $relation_type ) {
+	if ( 'dns-prefetch' === $relation_type ) {
 		/** This filter is documented in wp-includes/formatting.php */
 		$emoji_svg_url = apply_filters( 'emoji_svg_url', 'https://s.w.org/images/core/emoji/2/svg/' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
 				"@wordpress/stylelint-config": "^20.0.1",
 				"eslint": "^8.8.0",
 				"eslint-plugin-react-hooks": "^4.3.0",
-				"prettier": "npm:wp-prettier@2.2.1-beta-1"
+				"prettier": "npm:wp-prettier@2.2.1-beta-1",
+				"sanitize-html": "^2.7.0"
 			},
 			"engines": {
 				"node": "16",
@@ -11141,6 +11142,18 @@
 				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
+		"node_modules/got/node_modules/type-fest": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.9",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -16514,6 +16527,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"dev": true
+		},
 		"node_modules/parse5": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -18835,6 +18854,38 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"node_modules/sanitize-html": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
+			"integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
+			"dev": true,
+			"dependencies": {
+				"deepmerge": "^4.2.2",
+				"escape-string-regexp": "^4.0.0",
+				"htmlparser2": "^6.0.0",
+				"is-plain-object": "^5.0.0",
+				"parse-srcset": "^1.0.2",
+				"postcss": "^8.3.11"
+			}
+		},
+		"node_modules/sanitize-html/node_modules/deepmerge": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sanitize-html/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/sass": {
 			"version": "1.49.8",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
@@ -20750,12 +20801,14 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+			"integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -20787,6 +20840,20 @@
 			"dev": true,
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/uc.micro": {
@@ -30338,6 +30405,14 @@
 				"responselike": "^2.0.0",
 				"to-readable-stream": "^2.0.0",
 				"type-fest": "^0.10.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "0.10.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+					"dev": true
+				}
 			}
 		},
 		"graceful-fs": {
@@ -34342,6 +34417,12 @@
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
 			"dev": true
 		},
+		"parse-srcset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+			"dev": true
+		},
 		"parse5": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -36030,6 +36111,34 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"sanitize-html": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
+			"integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
+			"dev": true,
+			"requires": {
+				"deepmerge": "^4.2.2",
+				"escape-string-regexp": "^4.0.0",
+				"htmlparser2": "^6.0.0",
+				"is-plain-object": "^5.0.0",
+				"parse-srcset": "^1.0.2",
+				"postcss": "^8.3.11"
+			},
+			"dependencies": {
+				"deepmerge": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+					"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+					"dev": true
+				}
+			}
+		},
 		"sass": {
 			"version": "1.49.8",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.49.8.tgz",
@@ -37526,10 +37635,12 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-			"dev": true
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.13.0.tgz",
+			"integrity": "sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==",
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -37555,6 +37666,13 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"typescript": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+			"integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+			"dev": true,
+			"peer": true
 		},
 		"uc.micro": {
 			"version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/stylelint-config": "^20.0.1",
 		"eslint": "^8.8.0",
 		"eslint-plugin-react-hooks": "^4.3.0",
-		"prettier": "npm:wp-prettier@2.2.1-beta-1"
+		"prettier": "npm:wp-prettier@2.2.1-beta-1",
+		"sanitize-html": "^2.7.0"
 	}
 }

--- a/src/block.json
+++ b/src/block.json
@@ -19,27 +19,27 @@
 		"relatedPosts": {
 			"type": "array",
 			"source": "query",
-			"selector": ".related-post",
+			"selector": ".xwp-country-card__related-post",
 			"query": {
 				"title": {
 					"type": "string",
-					"selector": ".title",
-					"source": "text"
+					"selector": ".xwp-country-card__related-post__heading",
+					"source": "html"
 				},
 				"excerpt": {
 					"type": "string",
-					"selector": ".excerpt",
-					"source": "text"
+					"selector": ".xwp-country-card__related-post__excerpt",
+					"source": "html"
 				},
 				"link": {
 					"type": "string",
-					"selector": ".link",
+					"selector": ".xwp-country-card__related-post__link",
 					"source": "attribute",
 					"attribute": "href"
 				},
 				"id": {
 					"type": "string",
-					"selector": ".link",
+					"selector": ".xwp-country-card__related-post__link",
 					"source": "attribute",
 					"attribute": "data-post-id"
 				}

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,30 +1,55 @@
-import countries from '../assets/countries.json';
-import './editor.scss';
+/**
+ * WordPress dependencies
+ */
 import { edit, globe } from '@wordpress/icons';
-import { BlockControls } from '@wordpress/block-editor';
-import { ComboboxControl, Placeholder, ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { getEmojiFlag } from './utils';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	ComboboxControl,
+	Placeholder,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import countries from '../assets/countries.json';
 import Preview from './preview';
+import { options, sanitizeAndStyle } from './utils';
+import './editor.scss';
 
-export default function Edit( { attributes, setAttributes } ) {
+export default function Edit( { attributes, setAttributes, isSelected } ) {
 	const { countryCode, relatedPosts } = attributes;
-	const options = Object.keys(countries).map(code => ({
-        value: code,
-        label:  getEmojiFlag( code ) + '  ' + countries[code] + ' — ' + code
-	}));
-
 	const [ isPreview, setPreview ] = useState();
 
-	useEffect( () => setPreview( countryCode ), [ countryCode ] );
+	/**
+	 * Two things will automatically show the preview:
+	 * 1 - changing the country code
+	 * 2 - navigating away from the block when the country code is already set
+	 */
+	useEffect( () => {
+		if ( ! isSelected && countryCode ) {
+			setPreview( true );
+		} else {
+			setPreview( countryCode );
+		}
+	}, [ countryCode, isSelected ] );
 
+	// Allow the edit button in the toolbar to toggle the preview.
 	const handleChangeCountry = () => {
-		if ( isPreview ) setPreview( false );
-		else if ( countryCode ) setPreview( true );
+		if ( isPreview ) {
+			setPreview( false );
+		} else if ( countryCode ) {
+			setPreview( true );
+		}
 	};
 
-	const handleChangeCountryCode = newCountryCode => {
+	// Set the new attribute for the country code and clear the related posts array when the country is changed.
+	const handleChangeCountryCode = ( newCountryCode ) => {
 		if ( newCountryCode && countryCode !== newCountryCode ) {
 			setAttributes( {
 				countryCode: newCountryCode,
@@ -33,50 +58,94 @@ export default function Edit( { attributes, setAttributes } ) {
 		}
 	};
 
+	/**
+	 * Get the related posts, excluding the post to which this block belongs.
+	 * The related posts will only update on the front end when the post is saved with a new country code,
+	 * it does not dynamically search for related posts on the front end.
+	 */
 	useEffect( () => {
 		async function getRelatedPosts() {
-			const postId = window.location.href.match( /post=([\d]+)/ )[ 1 ];
-			const response = await window.fetch( `/wp-json/wp/v2/posts?search=${ countries[ countryCode ] }&exclude=${ postId }` );
+			const postId = select( 'core/editor' ).getCurrentPostId();
 
-			if ( ! response.ok )
+			// The search term comes from a file in this project. If that changes it needs to be escaped properly.
+			const searchUrl = addQueryArgs( '/wp-json/wp/v2/posts', {
+				search: countries[ countryCode ],
+				exclude: postId,
+			} );
+
+			// This could use @wordpress/apiFetch also but not with async/await I think.
+			const response = await window.fetch( searchUrl );
+
+			if ( ! response.ok ) {
 				throw new Error( `HTTP error! Status: ${ response.status }` );
+			}
 
 			const posts = await response.json();
 
 			setAttributes( {
-				relatedPosts: posts?.map( ( relatedPost ) => ( {
-					...relatedPost,
-					title: relatedPost.title?.rendered || relatedPost.link,
-					excerpt: relatedPost.excerpt?.rendered || '',
-				} ) ) || [],
+				relatedPosts:
+					posts?.map( ( relatedPost ) => ( {
+						...relatedPost,
+						title: relatedPost.title
+							? sanitizeAndStyle(
+									relatedPost.title.rendered,
+									countryCode,
+									'title'
+							  )
+							: relatedPost.link,
+						excerpt: relatedPost.excerpt
+							? sanitizeAndStyle(
+									relatedPost.excerpt.rendered,
+									countryCode,
+									'excerpt'
+							  )
+							: '',
+					} ) ) || [],
 			} );
 		}
 
 		getRelatedPosts();
-	}, [countryCode, setAttributes] );
+	}, [ countryCode, setAttributes ] );
 
 	return (
-		<>
-			<BlockControls>
-				<ToolbarGroup>
-						<ToolbarButton label={ __( 'Change Country', 'xwp-country-card' ) }
-							icon={ edit } onClick={ handleChangeCountry } disabled={ ! Boolean( countryCode ) } />
-				</ToolbarGroup>
-			</BlockControls>
-			<div>
-				{ isPreview ? <Preview countryCode={ countryCode } relatedPosts={ relatedPosts }/> : <Placeholder icon={ globe } label={ __( 'XWP Country Card', 'xwp-country-card' ) }
-								 isColumnLayout={ true }
-								 instructions={ __( 'Type in a name of a contry you want to display on you site.', 'xwp-country-card' ) }>
-						<ComboboxControl
-							label={ __( 'Country', 'xwp-country-card' ) }
-                            hideLabelFromVision
-							options={ options }
-							value={ countryCode }
-							onChange={ handleChangeCountryCode }
-                            allowReset={true}
+		<div { ...useBlockProps() }>
+			{
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							label={ __( 'Change Country', 'xwp-country-card' ) }
+							icon={ edit }
+							onClick={ handleChangeCountry }
+							disabled={ ! Boolean( countryCode ) }
 						/>
-					</Placeholder> }
-			</div>
-		</>
+					</ToolbarGroup>
+				</BlockControls>
+			}
+			{ isPreview ? (
+				<Preview
+					countryCode={ countryCode }
+					relatedPosts={ relatedPosts }
+				/>
+			) : (
+				<Placeholder
+					icon={ globe }
+					label={ __( 'XWP Country Card', 'xwp-country-card' ) }
+					isColumnLayout={ true }
+					instructions={ __(
+						'Type in a name of a contry you want to display on you site.',
+						'xwp-country-card'
+					) }
+				>
+					<ComboboxControl
+						label={ __( 'Country', 'xwp-country-card' ) }
+						hideLabelFromVision
+						options={ options }
+						value={ countryCode }
+						onChange={ handleChangeCountryCode }
+						allowReset={ true }
+					/>
+				</Placeholder>
+			) }
+		</div>
 	);
 }

--- a/src/edit.js
+++ b/src/edit.js
@@ -73,35 +73,43 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
 				exclude: postId,
 			} );
 
-			// This could use @wordpress/apiFetch also but not with async/await I think.
-			const response = await window.fetch( searchUrl );
+			try {
+				const response = await window.fetch( searchUrl );
 
-			if ( ! response.ok ) {
-				throw new Error( `HTTP error! Status: ${ response.status }` );
+				if ( ! response.ok ) {
+					throw new Error(
+						`HTTP error! Status: ${ response.status }`
+					);
+				}
+
+				const posts = await response.json();
+
+				setAttributes( {
+					relatedPosts:
+						posts?.map( ( relatedPost ) => ( {
+							...relatedPost,
+							title: relatedPost.title
+								? sanitizeAndStyle(
+										relatedPost.title.rendered,
+										countryCode,
+										'title'
+								  )
+								: relatedPost.link,
+							excerpt: relatedPost.excerpt
+								? sanitizeAndStyle(
+										relatedPost.excerpt.rendered,
+										countryCode,
+										'excerpt'
+								  )
+								: '',
+						} ) ) || [],
+				} );
+			} catch ( error ) {
+				// Error logging goes here.
+				setAttributes( {
+					relatedPosts: [],
+				} );
 			}
-
-			const posts = await response.json();
-
-			setAttributes( {
-				relatedPosts:
-					posts?.map( ( relatedPost ) => ( {
-						...relatedPost,
-						title: relatedPost.title
-							? sanitizeAndStyle(
-									relatedPost.title.rendered,
-									countryCode,
-									'title'
-							  )
-							: relatedPost.link,
-						excerpt: relatedPost.excerpt
-							? sanitizeAndStyle(
-									relatedPost.excerpt.rendered,
-									countryCode,
-									'excerpt'
-							  )
-							: '',
-					} ) ) || [],
-			} );
 		}
 
 		getRelatedPosts();

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -1,3 +1,4 @@
-.wp-block-xwp-country-card .components-form-token-field__suggestion {
+.wp-block-xwp-country-card,
+.components-form-token-field__suggestion {
 	white-space: pre-wrap;
 }

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,51 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import countries from '../assets/countries.json';
 import continentNames from '../assets/continent-names.json';
 import continents from '../assets/continents.json';
-import { getEmojiFlag } from './utils';
-import { __, sprintf } from '@wordpress/i18n';
+import { getEmojiFlag, sanitizeInContext } from './utils';
 
 export default function Preview( { countryCode, relatedPosts } ) {
 	if ( ! countryCode ) return null;
 
 	const emojiFlag = getEmojiFlag( countryCode ),
-	      hasRelatedPosts = relatedPosts?.length > 0;
+		hasRelatedPosts = relatedPosts?.length > 0;
 
 	return (
 		<div className="xwp-country-card">
-			<div className="xwp-country-card__media" data-emoji-flag={ emojiFlag }>
-				<div className="xwp-country-card-flag">
-					{ emojiFlag }
-				</div>
+			<div
+				className="xwp-country-card__media"
+				data-emoji-flag={ emojiFlag }
+			>
+				<div className="xwp-country-card-flag">{ emojiFlag }</div>
 			</div>
 			<h3 className="xwp-country-card__heading">
-				{ __( 'Hello from' ) }
-				{ ' ' }
-				<strong>{ countries[countryCode] }</strong>
-				{ ' ' }
-				(<span className="xwp-country-card__country-code">{ countryCode }</span>),
-				{ ' ' }
-				{ continentNames[continents[countryCode]] }!
+				{ __( 'Hello from' ) }{ ' ' }
+				<strong>{ countries[ countryCode ] }</strong> (
+				<span className="xwp-country-card__country-code">
+					{ countryCode }
+				</span>
+				), { continentNames[ continents[ countryCode ] ] }!
 			</h3>
 			<div className="xwp-country-card__related-posts">
 				<h3 className="xwp-country-card__related-posts__heading">
-					{ hasRelatedPosts ? sprintf( __( 'There are %d related posts:' ), relatedPosts.length ) : __( 'There are no related posts.' ) }
+					{ hasRelatedPosts
+						? sprintf(
+								/* translators: %d will be replaced by the number of related posts */
+								_n(
+									'There is %d related post',
+									'There are %d related posts:',
+									relatedPosts.length,
+									'xwp-country-card'
+								),
+								relatedPosts.length
+						  )
+						: __( 'There are no related posts.' ) }
 				</h3>
 				{ hasRelatedPosts && (
-					<ul className="xwp-country-card__related-posts-list">
+					<ul className="xwp-country-card__related-posts__list">
 						{ relatedPosts.map( ( relatedPost, index ) => (
-							<li key={ index } className="related-post">
-									<a
-										className="link"
-										href={ relatedPost.link }
-										data-post-id={ relatedPost.id }
-									>
-										<h3 className="title">
-											{ relatedPost.title }
-										</h3>
-										<p className="excerpt">
-											{ relatedPost.excerpt }
-										</p>
-									</a>
+							<li
+								key={ index }
+								className="xwp-country-card__related-post"
+							>
+								<a
+									className="xwp-country-card__related-post__link"
+									href={ relatedPost.link }
+									data-post-id={ relatedPost.id }
+								>
+									{ /* eslint-disable-next-line jsx-a11y/heading-has-content */ }
+									<h4
+										className="xwp-country-card__related-post__heading"
+										dangerouslySetInnerHTML={ {
+											__html: sanitizeInContext(
+												relatedPost.title,
+												'title'
+											),
+										} }
+									></h4>
+									<div
+										className="xwp-country-card__related-post__excerpt"
+										dangerouslySetInnerHTML={ {
+											__html: sanitizeInContext(
+												relatedPost.excerpt,
+												'excerpt'
+											),
+										} }
+									></div>
+								</a>
 							</li>
 						) ) }
 					</ul>

--- a/src/save.js
+++ b/src/save.js
@@ -1,8 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
 import Preview from './preview';
 
 export default function Save( { attributes } ) {
+	const blockProps = useBlockProps.save();
 	return (
-		<div>
+		<div { ...blockProps }>
 			<Preview { ...attributes } />
 		</div>
 	);

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,6 +1,6 @@
 .xwp-country-card {
 	border: 1px solid #dcdcde;
-	box-shadow: 0px 1px 1px rgba(#000, 0.05);
+	box-shadow: 0 1px 1px rgba(#000, 0.05);
 
 	.xwp-country-card__media {
 		align-items: center;
@@ -10,20 +10,20 @@
 		justify-content: center;
 		overflow: hidden;
 		position: relative;
-		margin: 0px;
+		margin: 0;
 
-		&:before {
+		&::before {
 			align-items: center;
 			content: attr(data-emoji-flag);
 			display: flex;
-			filter: blur(3vh) saturate(3) contrast(1) opacity(0.4);
+			filter: blur(10vh) saturate(3) contrast(1) opacity(0.4);
 			font-size: calc(800px + 3vh);
 			height: 100%;
 			justify-content: center;
-			left: 0px;
+			left: 0;
 			pointer-events: none;
 			position: absolute;
-			top: 0px;
+			top: 0;
 			width: 100%;
 		}
 	}
@@ -32,12 +32,21 @@
 .xwp-country-card-flag {
 	font-size: calc(200px + 3vw);
 	line-height: 1;
+	z-index: 1;
 }
 
 .xwp-country-card__heading {
 	padding: 1.5rem;
 	margin: 0;
 	font-size: 2rem;
+}
+
+.xwp-country-card__country-code {
+	text-decoration: underline #000 dotted;
+}
+
+.xwp-country-card__searched-word {
+	font-weight: 700;
 }
 
 .xwp-country-card__related-posts {
@@ -47,23 +56,27 @@
 }
 
 .xwp-country-card__related-posts__heading {
-	margin: 0px;
+	margin: 0;
 	font-size: 1.5rem;
 }
 
-.xwp-country-card__related-posts-list {
+.xwp-country-card__related-posts__list {
 	padding-left: 1.5rem;
 }
 
-.related-post + .related-post {
-	margin-top: 1.5rem;
+.xwp-country-card__related-post {
+	margin-top: 1rem;
 }
 
-.related-post .title {
-	margin: 0px;
+.xwp-country-card__related-post__heading {
+	margin: 0;
 	font-size: 1.5rem;
 }
 
-.related-post .excerpt {
-	margin: 0px;
+.xwp-country-card__related-post__excerpt {
+	margin: 0;
+}
+
+.xwp-country-card__related-post-link {
+	text-decoration: underline;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -89,7 +89,7 @@ export const options = Object.keys( countries ).map( ( code ) => ( {
  * @return {Array} An array of the words which should be in bold.
  */
 const getWordsToBold = ( countryCode ) => {
-	return [ countries[ countryCode ], 'ipsum' ];
+	return [ countries[ countryCode ], 'ipsum', 'world' ];
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,10 +44,10 @@ export function sanitizeAndStyle( content, countryCode, context ) {
 		return sanitizeInContext( content, context );
 	}
 
-	const markedContent = wordsToBold.reduce( ( wordToBold ) => {
+	const markedContent = wordsToBold.reduce( ( newContent, wordToBold ) => {
 		const boldMarkup = `<span class="xwp-country-card__searched-word">${ wordToBold }</span>`;
-		return content.split( wordToBold ).join( boldMarkup );
-	} );
+		return newContent.split( wordToBold ).join( boldMarkup );
+	}, content );
 
 	return sanitizeInContext( markedContent, context );
 }
@@ -89,7 +89,7 @@ export const options = Object.keys( countries ).map( ( code ) => ( {
  * @return {Array} An array of the words which should be in bold.
  */
 const getWordsToBold = ( countryCode ) => {
-	return [ countries[ countryCode ], 'world' ];
+	return [ countries[ countryCode ], 'ipsum' ];
 };
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,24 @@
+/**
+ * External dependencies
+ */
+import sanitize from 'sanitize-html';
+
+/**
+ * WordPress dependencies
+ */
+import { sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import countries from '../assets/countries.json';
+
+/**
+ * Gets the string to use for the correct country flag.
+ *
+ * @param {string} countryCode The two character country code.
+ * @return {string} The string which corresponds to the correct flag.
+ */
 export function getEmojiFlag( countryCode ) {
 	return String.fromCodePoint(
 		...countryCode
@@ -6,3 +27,77 @@ export function getEmojiFlag( countryCode ) {
 			.map( ( char ) => 127397 + char.charCodeAt() )
 	);
 }
+
+/**
+ * Adds markup around a word or string in content so that it may be styled.
+ *
+ * @param {string} content     The content to be searched for the word to be styled.
+ * @param {string} countryCode The country code chosen.
+ * @param {string} context     What context is this content? Eg 'excerpt' or 'title'.
+ * @return {string} The sanitized content with the markup to style it.
+ */
+export function sanitizeAndStyle( content, countryCode, context ) {
+	if ( ! content ) return;
+
+	const wordsToBold = getWordsToBold( countryCode, context );
+	if ( ! wordsToBold || wordsToBold.length < 1 ) {
+		return sanitizeInContext( content, context );
+	}
+
+	const markedContent = wordsToBold.reduce( ( wordToBold ) => {
+		const boldMarkup = `<span class="xwp-country-card__searched-word">${ wordToBold }</span>`;
+		return content.split( wordToBold ).join( boldMarkup );
+	} );
+
+	return sanitizeInContext( markedContent, context );
+}
+
+/**
+ *
+ * Sanitize the content passed; can be contextual.
+ * This currently has the context as a parameter to allow for more flexible sanitization. If needed this only has to change here.
+ *
+ * @param {string} content The content to be sanitized.
+ * @param {string} context The context for the content, eg 'excerpt' or 'title'.
+ * @return {string} The santized content.
+ */
+// eslint-disable-next-line no-unused-vars
+export function sanitizeInContext( content, context ) {
+	return sanitize( content, allowSpans );
+}
+
+/*
+ * The label is not escaped in this object as the data comes from a file in this project.
+ * If the data changes to come from outside this project, it must be escaped.
+ * For translation of the label, the countries.json needs to be edited.
+ */
+export const options = Object.keys( countries ).map( ( code ) => ( {
+	value: code,
+	label: sprintf(
+		'%1$s %2$s - %3$s',
+		getEmojiFlag( code ),
+		countries[ code ],
+		code
+	),
+} ) );
+
+/**
+ *
+ * Get a list of the words which should be formatted.
+ *
+ * @param {string} countryCode
+ * @return {Array} An array of the words which should be in bold.
+ */
+const getWordsToBold = ( countryCode ) => {
+	return [ countries[ countryCode ], 'world' ];
+};
+
+/**
+ * Used in sanitize() to allow only span tags with a class.
+ */
+const allowSpans = {
+	allowedTags: [ 'span' ],
+	allowedAttributes: {
+		span: [ 'class' ],
+	},
+};


### PR DESCRIPTION
The block should be more stable and easier to test if needed. There are some questions and changes which may need to be made depending on the exact specifications. Style and formatting was updated.

There is a question about the exact rules and method for the markup in the related posts title and excerpt. Currently it adds a `span` with a class for styling to certain words in both – the country chosen and the words "world" and "ipsum" – however this assumes that there is nothing adding html to the title or excerpt. In particular, that I don't need to worry about the selected words being in an html tag attribute. To change this behaviour, change the function `sanitizeAndStyle()` in `utils.js`. 

Also, I've used the `sanitize-html` package but this can be changed in the file `utils.js` by updating the `sanitizeInContext()` function.

There are two places the WordPress api wasn't used:

1. `fetch` was used instead of `apiFetch`
2. `RawHTML` wasn't used so the markup would be a bit cleaner

